### PR TITLE
Feat: can return one satellite by id

### DIFF
--- a/app/controllers/api/v1/satellites_controller.rb
+++ b/app/controllers/api/v1/satellites_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::SatellitesController < ApplicationController
+  before_action :set_satellite, only: [:show]
+
+  def show
+    satellite_json_response(@satellite)
+  end
+
+  private
+
+  def set_satellite
+    @satellite = Satellite.find(params[:id])
+  end
+
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  include Response
 end

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,0 +1,7 @@
+module Response
+
+  def satellite_json_response(object, status = :ok)
+    render json: SatelliteSerializer.new(object), status: status
+  end
+
+end

--- a/app/serializers/satellite_serializer.rb
+++ b/app/serializers/satellite_serializer.rb
@@ -1,0 +1,4 @@
+class SatelliteSerializer
+  include JSONAPI::Serializer
+  attributes :norad_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  namespace :api do
+    namespace :v1 do
+      resources :satellites, only: [:show]
+    end
+  end
 end

--- a/spec/requests/api/v1/satellites_request_spec.rb
+++ b/spec/requests/api/v1/satellites_request_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'Satellites API' do
+
+  it 'can return one satellite by id' do
+
+    sat_1 = FactoryBot.create(:satellite)
+    sat_2 = FactoryBot.create(:satellite)
+    sat_3 = FactoryBot.create(:satellite)
+
+    get "/api/v1/satellites/#{sat_1.id}"
+
+    expect(response).to be_successful
+
+    satellite = JSON.parse(response.body, symbolize_names: true)[:data]
+
+    expect(satellite).to have_key(:id)
+    expect(satellite[:id].to_i).to eq(sat_1.id)
+
+    expect(satellite[:attributes]).to have_key(:norad_id)
+    expect(satellite[:attributes][:norad_id]).to eq(sat_1.norad_id)
+
+  end
+
+end


### PR DESCRIPTION
**Issue Name:**Satellite Show Page   
**Issue Resolves: #13**

**Introduces:**
- Add: Exposes `GET /api/v1/satellites/{{satellite_id}}` endpoint, which returns JSON including satellite NORAD ID number.
- Add: General serializing set up and associated files. 
- Add: 

**Fixes:**
- Refactor: 
- Add: 
- N/A


<br>

**Testing Changes:**

   - [x] No Tests have been changed
   - [ ] Some Tests have been changed. Please describe which ones: 
   - [ ] All of the Tests have been changed. Please describe what in the world happened:
  
<br>

**Testing Functionality:**
   - [x] All Tests are Passing
   - [ ] Some Tests are not passing. Please describe which ones:
   - [ ] All Postman Tests are Passing
   - [ ] Some Postman Tests produce errors. Please describe which ones:
   - [ ] Coverage report generated. Please report RSpec coverage: x / x LOC (x%) covered.

<br>

**Feature Functionality:**
   - [x] The code will run locally
   - [ ] The code will not run locally. Please describe what features:
   - [ ] The code will run on Heroku
   - [ ] The code will not run on Heroku. Please describe what features: 
   - [ ] Circle CI is fully functional.
   - [ ] Circle CI is not fully functional. Please describe which parts: 



<br>

**Add any optional / additional extended information:**

(Will add simplecov to next PR. Thank you for reminder that this is not set up on BE.)
