### PR TITLE
Feat: User satellites by user_id API endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,9 +90,13 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     msgpack (1.5.6)
     nio4r (2.5.8)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     pg (1.4.3)
@@ -186,6 +190,7 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
+  ruby
   x86_64-darwin-21
 
 DEPENDENCIES

--- a/app/controllers/api/v1/satellites_controller.rb
+++ b/app/controllers/api/v1/satellites_controller.rb
@@ -5,6 +5,18 @@ class Api::V1::SatellitesController < ApplicationController
     satellite_json_response(@satellite)
   end
 
+  def find_by_user_id
+    user_sat_ids = UserSatellite.where(user_id: params[:user_id])
+    
+    sat_ids = user_sat_ids.map do |ids|
+      ids[:satellite_id]
+    end.uniq
+
+    satellites = Satellite.find(sat_ids)
+
+    satellite_json_response(satellites)
+  end
+
   private
 
   def set_satellite

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      get "/satellites/find_by_user_id", to: "satellites#find_by_user_id"
       get "/messages/find_by_sat_id", to: "messages#find_by_sat_id"
-
+      
       resources :satellites, only: [:show]
     end
   end

--- a/spec/requests/api/v1/satellites_request_spec.rb
+++ b/spec/requests/api/v1/satellites_request_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 describe 'Satellites API' do
-
   it 'can return one satellite by id' do
-
     sat_1 = FactoryBot.create(:satellite)
     sat_2 = FactoryBot.create(:satellite)
     sat_3 = FactoryBot.create(:satellite)
@@ -19,7 +17,34 @@ describe 'Satellites API' do
 
     expect(satellite[:attributes]).to have_key(:norad_id)
     expect(satellite[:attributes][:norad_id]).to eq(sat_1.norad_id)
-
   end
 
+  it 'can return all satellites associated with user' do
+    user1 = FactoryBot.create(:user)
+    sat_1 = FactoryBot.create(:satellite)
+    sat_2 = FactoryBot.create(:satellite)
+    sat_3 = FactoryBot.create(:satellite)
+    user_sat1 = FactoryBot.create(:user_satellite, user_id: user1.id, satellite_id: sat_1.id)
+    user_sat2 = FactoryBot.create(:user_satellite, user_id: user1.id, satellite_id: sat_2.id)
+    user_sat3 = FactoryBot.create(:user_satellite, user_id: user1.id, satellite_id: sat_3.id)
+
+    get "/api/v1/satellites/find_by_user_id?user_id=#{user1.id}"
+
+    expect(response).to be_successful
+
+    user_satellites = JSON.parse(response.body, symbolize_names: true)
+
+    expect(user_satellites[:data].count).to eq(3)
+
+    user_satellites[:data].each do |satellite|
+      expect(satellite).to have_key(:id)
+      expect(satellite[:id]).to be_a(String)
+
+      expect(satellite).to have_key(:type)
+      expect(satellite[:type]).to be_a(String)
+
+      expect(satellite[:attributes]).to have_key(:norad_id)
+      expect(satellite[:attributes][:norad_id]).to be_a(Integer)
+    end
+  end
 end


### PR DESCRIPTION
**Issue Name: Dashboard Page - User Story #Two**,   
**Issue Resolves: #10**

**Introduces:**
- Add: [Test to return all satellites associated with user](https://github.com/messages-from-the-stars/messages-from-the-stars-be/commit/c38dcf81ae713a0e2bc3e4832b5da3c260a8c0f0)
- Add: [Satellites find by user id route](https://github.com/messages-from-the-stars/messages-from-the-stars-be/commit/f7d20d25005c367bcc71380104bd94d460636677)
- Add: [Feature to get all satellites associated to a user API endpoint](https://github.com/messages-from-the-stars/messages-from-the-stars-be/commit/5290772f222a0abdf974fed1e54b0a1d2e8ca7de)

**Fixes:**
- N/A


<br>

**Testing Changes:**

   - [x] No Tests have been changed
   - [ ] Some Tests have been changed. Please describe which ones: 
   - [ ] All of the Tests have been changed. Please describe what in the world happened:
  
<br>

**Testing Functionality:**
   - [x] All Tests are Passing
   - [ ] Some Tests are not passing. Please describe which ones:
   - [x] All Postman Tests are Passing
   - [ ] Some Postman Tests produce errors. Please describe which ones:
   - [ ] Coverage report generated. Please report RSpec coverage: 267 / 269 LOC (99.26%) covered.

<br>

**Feature Functionality:**
   - [x] The code will run locally
   - [ ] The code will not run locally. Please describe what features:
   - [ ] The code will run on Heroku
   - [ ] The code will not run on Heroku. Please describe what features: 
   - [ ] Circle CI is fully functional.
   - [ ] Circle CI is not fully functional. Please describe which parts: 



<br>

**Add any optional / additional extended information:**
```
Not sure if end point is already functioning on Heroku or Circle CI. Need to check if this is up and working as we were previously having some sort of bundling issue in Circle CI which was disrupting our heroku deployment flow. Alex paired reviewed on zoom call on Sep 15.
